### PR TITLE
Strip quoted replies, save content.txt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 repos:
   # Ruff linting and formatting (already used in project)
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.8
+    rev: v0.14.9
     hooks:
       - id: ruff
         args: [--fix]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,11 +172,13 @@ resolved_target_dir/          # From resolution order: --output-dir > env var > 
 ├── rt37603/                  # Ticket directory (rt{ticket_id} format)
 │   ├── metadata.txt          # Basic ticket information
 │   ├── 1492666/              # History entry directory
-│   │   ├── message.txt       # History entry content
+│   │   ├── message.txt       # Full RT history entry (raw format)
+│   │   ├── content.txt       # New content only (quoted replies stripped)
 │   │   ├── n800.pdf          # Attachment with n-prefix for sorting
 │   │   └── n801.xlsx         # Additional attachments
 │   └── 1492934/              # Additional history entries
-│       └── message.txt
+│       ├── message.txt
+│       └── content.txt
 └── rt37604/                  # Another ticket directory
     ├── metadata.txt
     └── ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pytest>=8.4.1",
-    "ruff>=0.12.5",
+    "ruff>=0.14.9",
 ]
 optional = [
     "anthropic>=0.60.0",
@@ -43,7 +43,7 @@ python_classes = ["Test*"]
 python_functions = ["test_*"]
 
 [tool.ruff]
-required-version = ">=0.12.8,<0.12.9"
+required-version = ">=0.14.9,<0.15.0"
 src = ["src", "tests"]
 target-version = "py313"
 

--- a/src/rt_tools/downloader.py
+++ b/src/rt_tools/downloader.py
@@ -25,7 +25,12 @@ try:
 except ImportError:
     openpyxl = None
 
-from .parser import parse_attachment_list, parse_history_list, parse_history_message
+from .parser import (
+    parse_attachment_list,
+    parse_history_list,
+    parse_history_message,
+    strip_quoted_reply,
+)
 from .session import RTSession
 
 logger = logging.getLogger(__name__)
@@ -107,6 +112,7 @@ class TicketDownloader:
             )
             history_item_text = history_item_payload.decode("utf-8")
             history_message = parse_history_message(history_item_text)
+            self._save_stripped_content(ticket_dir, history_id, history_message.content)
             for attachment in history_message.attachments:
                 if attachment.size != "0b":
                     mime_type = attachment_index[attachment.id].mime_type
@@ -190,6 +196,22 @@ class TicketDownloader:
         message_file.write_bytes(rt_data.payload)
         logger.info(f"Created {message_file}")
         return rt_data.payload
+
+    def _save_stripped_content(
+        self, target_dir: Path, history_id: str, content: str | None
+    ) -> None:
+        """Save non-quoted message content to content.txt.
+
+        Skips saving if content is None or entirely quoted (empty after strip).
+        """
+        if not content:
+            return
+        stripped = strip_quoted_reply(content)
+        if not stripped:
+            return
+        content_file = target_dir / history_id / "content.txt"
+        content_file.write_text(stripped + "\n", encoding="utf-8")
+        logger.info(f"Created {content_file}")
 
     def _download_attachment_ist(
         self, ticket_id: str, target_dir: Path

--- a/src/rt_tools/parser.py
+++ b/src/rt_tools/parser.py
@@ -197,8 +197,10 @@ def parse_history_message(text: str) -> HistoryMessage:
 def strip_quoted_reply(content: str) -> str:
     """Strip quoted reply sections, keeping only new content.
 
-    RT emails include accumulated quoted replies using the pattern
-    "On <date>, <username> wrote:" followed by indented prior content.
+    RT emails include accumulated quoted replies using two patterns:
+    - RT/webmail style: "On <date>, <username> wrote:"
+    - Outlook style: "From: <sender>\\nSent: <date>"
+
     Since each history entry is preserved separately, quoted text is
     redundant.
 
@@ -209,7 +211,11 @@ def strip_quoted_reply(content: str) -> str:
         Content up to the first quoted reply boundary, rstripped.
         Returns the original content rstripped if no quoting is found.
     """
-    match = search(r"(^|\n)On .+, .+ wrote:", content, MULTILINE)
+    match = search(
+        r"(^|\n)(On .+, .+ wrote:|From: .+\nSent: )",
+        content,
+        MULTILINE,
+    )
     if match:
         cut = match.start() if content[match.start()] == "\n" else 0
         return content[:cut].rstrip()

--- a/src/rt_tools/parser.py
+++ b/src/rt_tools/parser.py
@@ -16,7 +16,7 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from dataclasses import field as dc_field
 from logging import getLogger
-from re import DOTALL, compile, findall, search
+from re import DOTALL, MULTILINE, compile, findall, search
 from textwrap import dedent
 
 logger = getLogger(__name__)
@@ -192,3 +192,25 @@ def parse_history_message(text: str) -> HistoryMessage:
         created=created,
         attachments=attachments,
     )
+
+
+def strip_quoted_reply(content: str) -> str:
+    """Strip quoted reply sections, keeping only new content.
+
+    RT emails include accumulated quoted replies using the pattern
+    "On <date>, <username> wrote:" followed by indented prior content.
+    Since each history entry is preserved separately, quoted text is
+    redundant.
+
+    Args:
+        content: Dedented message content from parse_history_message()
+
+    Returns:
+        Content up to the first quoted reply boundary, rstripped.
+        Returns the original content rstripped if no quoting is found.
+    """
+    match = search(r"(^|\n)On .+, .+ wrote:", content, MULTILINE)
+    if match:
+        cut = match.start() if content[match.start()] == "\n" else 0
+        return content[:cut].rstrip()
+    return content.rstrip()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -8,6 +8,7 @@ from rt_tools.parser import (
     parse_attachment_list,
     parse_history_list,
     parse_history_message,
+    strip_quoted_reply,
 )
 
 EXPECTED_CONTENT = """Hi All,
@@ -147,6 +148,46 @@ def test_parse_message_attachments(sample_history_data):
     msg = parse_history_message(sample_history_data)
     assert msg.attachments[0] == Attachment(id="1483995", name="untitled", size="0b")
     assert msg.attachments[2].name == "Example Workbook.xlsx"
+
+
+def test_strip_quoted_reply_no_quotes():
+    content = "Hi,\n\nThis is a message.\n\nThanks,\nOne"
+    assert strip_quoted_reply(content) == "Hi,\n\nThis is a message.\n\nThanks,\nOne"
+
+
+def test_strip_quoted_reply_single_level():
+    content = (
+        "Files are ready.\n"
+        "On Fri Aug 01 17:00:00 2025, user001 wrote:\n\n"
+        "  Original message."
+    )
+    assert strip_quoted_reply(content) == "Files are ready."
+
+
+def test_strip_quoted_reply_nested():
+    # Only the first "On...wrote:" boundary matters; everything after is stripped
+    content = (
+        "Done.\n"
+        "On Mon Aug 04 16:47:07 2025, user002 wrote:\n\n"
+        "  Earlier message.\n"
+        "  On Fri Aug 01 2025, user001 wrote:\n\n"
+        "    Original."
+    )
+    assert strip_quoted_reply(content) == "Done."
+
+
+def test_strip_quoted_reply_leading_quote():
+    # Entire content is a quoted reply — result is empty, returns ""
+    content = "On Fri Aug 01 16:00:00 2025, user001 wrote:\n\n  Hi there."
+    assert strip_quoted_reply(content) == ""
+
+
+def test_strip_quoted_reply_fixture_1490011(fixtures_dir):
+    text = (fixtures_dir / "rt37525_sanitized" / "1490011" / "message.txt").read_text()
+    msg = parse_history_message(text)
+    stripped = strip_quoted_reply(msg.content)
+    assert "On Fri Aug 01 16:02:30 2025, user001 wrote:" not in stripped
+    assert "No problem! The files are copying now." in stripped
 
 
 def test_parse_attachment_list_edge_cases():

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -182,6 +182,24 @@ def test_strip_quoted_reply_leading_quote():
     assert strip_quoted_reply(content) == ""
 
 
+def test_strip_quoted_reply_outlook_style():
+    content = (
+        "Hi Evette,\n\n"
+        "I cc ed you on the e-mail with SRA.\n\n"
+        "Thank you\n\n"
+        "Ravi\n\n"
+        "From: Evette Skinner via RT <rt@hgsc.bcm.tmc.edu>\n"
+        "Sent: Monday, September 8, 2025 1:06 PM\n"
+        "To: Raveendran, Muthuswamy <raveendr@bcm.edu>\n"
+        "Subject: RE: [MFTS #37719] Replace existing data\n\n"
+        "Hi Ravi,\n\n"
+        "Previous message content."
+    )
+    assert strip_quoted_reply(content) == (
+        "Hi Evette,\n\nI cc ed you on the e-mail with SRA.\n\nThank you\n\nRavi"
+    )
+
+
 def test_strip_quoted_reply_fixture_1490011(fixtures_dir):
     text = (fixtures_dir / "rt37525_sanitized" / "1490011" / "message.txt").read_text()
     msg = parse_history_message(text)

--- a/tests/test_ticket_downloader.py
+++ b/tests/test_ticket_downloader.py
@@ -396,6 +396,11 @@ def test_download_ticket_convenience_function(mock_session):
         assert (ticket_dir / "history.txt").exists()
         assert (ticket_dir / "attachments.txt").exists()
 
+        # Verify content.txt is created for history entries with non-empty content
+        assert (ticket_dir / "456" / "content.txt").exists()
+        assert (ticket_dir / "457" / "content.txt").exists()
+        assert (ticket_dir / "458" / "content.txt").exists()
+
 
 def test_download_metadata_success(mock_session):
     """Test successful metadata download."""


### PR DESCRIPTION
## Summary

- Add `strip_quoted_reply()` to `parser.py`, handling both RT/webmail (`On … wrote:`) and Outlook (`From: … / Sent: …`) quoting styles
- Save stripped content to `content.txt` alongside `message.txt` for each history entry (skipped when content is entirely quoted or absent)
- Upgrade ruff from 0.12.8 to 0.14.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)